### PR TITLE
Added AWS temporary access token example.

### DIFF
--- a/examples/get-aws-access-token.py
+++ b/examples/get-aws-access-token.py
@@ -1,0 +1,66 @@
+# Requires Python 3.6+
+import sys
+import csv
+import getopt
+
+# Import the PrivX python library.
+import privx_api
+
+# Import the configs.
+import config
+
+# Initialize the API.
+api = privx_api.PrivXAPI(config.HOSTNAME, config.HOSTPORT, config.CA_CERT,
+                         config.OAUTH_CLIENT_ID, config.OAUTH_CLIENT_SECRET)
+
+# Authenticate.
+# NOTE: fill in your credentials from secure storage, this is just an example
+api.authenticate("API client ID", "API client secret")
+
+def usage():
+    print("Example for fetching AWS temporary access token via PrivX role.\nRequires mapping AWS role to PrivX role in PrivX admin console.\nIf PrivX user has a role with AWS role mapping, you can use '-r awsroleid' to acquire a token with assumed permissions via PrivX.\n")
+    print(sys.argv[0], "-h or --help")
+    print(sys.argv[0], "-r awsroleid")
+    print(sys.argv[0], "--awsrole awsroleid")
+    print(sys.argv[0], "--list")
+
+
+def print_awsroles(resp):
+    if resp.ok():
+        print(resp.data())
+    else:
+        print(resp.data())
+        sys.exit(2)
+
+def print_token(resp):
+    if resp.ok():
+        print(resp.data())
+    else:
+        print(resp.data())
+        sys.exit(2)
+
+def main():
+    if (len(sys.argv) < 2):
+        usage()
+        sys.exit(2)
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "hlr:", ["help", "list", "awsrole="])
+    except getopt.GetoptError:
+        usage()
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt in ("-h", "--help"):
+            usage()
+            sys.exit()
+        elif opt in ("-l", "--list"):
+            resp = api.list_awsroles()
+            print_awsroles(resp)
+        elif opt in ("-r", "--awsrole"):
+            resp = api.get_awstoken(arg, 900)
+            print_token(resp)
+        else:
+            usage()
+
+
+if __name__ == '__main__':
+    main()

--- a/privx_api/privx_api.py
+++ b/privx_api/privx_api.py
@@ -150,8 +150,7 @@ class PrivXAPI(object):
         return url
 
     def _get_context(self) -> ssl.SSLContext:
-        return ssl._create_unverified_context()
-#        return ssl.create_default_context(cadata=self._ca_cert)
+        return ssl.create_default_context(cadata=self._ca_cert)
 
     def _get_connection(self) -> http.client.HTTPSConnection:
         return http.client.HTTPSConnection(
@@ -179,7 +178,7 @@ class PrivXAPI(object):
             headers=headers,
         )
         response = conn.getresponse()
-        if response.status >= 400:
+        if response.status != 200:
             raise InternalAPIException(
                 "Invalid response: ", response.status)
 
@@ -209,12 +208,8 @@ class PrivXAPI(object):
             self._build_url(urlname, path_params, query_params),
             headers=self._get_headers(),
         )
-        response = conn.getresponse()
-        if response.status >= 400:
-            raise InternalAPIException(
-                "Invalid response: ", response.status)
 
-        return response
+        return conn.getresponse()
 
     def _http_get_no_auth(self, urlname: str) -> http.client.HTTPResponse:
         headers = self._get_headers()
@@ -226,12 +221,8 @@ class PrivXAPI(object):
             self._build_url(urlname),
             headers=headers,
         )
-        response = conn.getresponse()
-        if response.status >= 400:
-            raise InternalAPIException(
-                "Invalid response: ", response.status)
 
-        return response
+        return conn.getresponse()
 
     def _http_post(self,
                    urlname: str,
@@ -250,12 +241,8 @@ class PrivXAPI(object):
             headers=self._get_headers(),
             body=json.dumps(body),
         )
-        response = conn.getresponse()
-        if response.status >= 400:
-            raise InternalAPIException(
-                "Invalid response: ", response.status)
 
-        return response
+        return conn.getresponse()
 
     def _http_put(self, urlname: str,
                   body=None,
@@ -272,12 +259,8 @@ class PrivXAPI(object):
             headers=self._get_headers(),
             body=json.dumps(body),
         )
-        response = conn.getresponse()
-        if response.status >= 400:
-            raise InternalAPIException(
-                "Invalid response: ", response.status)
 
-        return response
+        return conn.getresponse()
 
     def _http_delete(self, urlname: str,
                   body=None,
@@ -294,12 +277,8 @@ class PrivXAPI(object):
             headers=self._get_headers(),
             body=json.dumps(body),
         )
-        response = conn.getresponse()
-        if response.status >= 400:
-            raise InternalAPIException(
-                "Invalid response: ", response.status)
 
-        return response
+        return conn.getresponse()
 
     #
     # Public functions.
@@ -458,7 +437,7 @@ class PrivXAPI(object):
 
         response = self._http_get("userstore.users",
                                   query_params=search_params)
-        return PrivXAPIResponse(response, response.status)
+        return PrivXAPIResponse(response, 200)
 
     def delete_local_user(self, user_id: str) -> PrivXAPIResponse:
         """
@@ -469,7 +448,7 @@ class PrivXAPI(object):
         """
         response = self._http_delete("userstore.user",
                                      path_params={'user_id': user_id})
-        return PrivXAPIResponse(response, response.status)
+        return PrivXAPIResponse(response, 200)
 
     #
     # Connection manager API.
@@ -491,7 +470,7 @@ class PrivXAPI(object):
         response = self._http_post("connection.manager.search",
                                    query_params=search_params,
                                    body=kw)
-        return PrivXAPIResponse(response, response.status)
+        return PrivXAPIResponse(response, 200)
 
 
     # List accessible AWS roles.
@@ -504,7 +483,7 @@ class PrivXAPI(object):
             PrivXAPIResponse
         """
         response = self._http_get("rolestore.awsroles")
-        return PrivXAPIResponse(response, response.status)
+        return PrivXAPIResponse(response, 200)
 
     # Fetch temporary AWS token for given AWS role name and TTL.
     # User needs to have the requested AWS role mapped to the available PrivX role by PrivX admin.
@@ -519,4 +498,4 @@ class PrivXAPI(object):
         response = self._http_get("rolestore.awstoken",
                                   path_params={'awsrole_id': awsrole_id},
                                   query_params={'ttl': ttl})
-        return PrivXAPIResponse(response, response.status)
+        return PrivXAPIResponse(response, 200)


### PR DESCRIPTION
Added AWS temporary access token example. Requires mapping AWS roles to PrivX roles to PrivX admin. See PrivX documentation.
Added some error handling.
