### PR TITLE
Added AWS temporary access token example

### DIFF
--- a/examples/get-aws-access-token.py
+++ b/examples/get-aws-access-token.py
@@ -1,6 +1,5 @@
 # Requires Python 3.6+
 import sys
-import csv
 import getopt
 
 # Import the PrivX python library.

--- a/examples/get-aws-access-token.py
+++ b/examples/get-aws-access-token.py
@@ -1,0 +1,66 @@
+# Requires Python 3.6+
+import sys
+import csv
+import getopt
+
+# Import the PrivX python library.
+import privx_api
+
+# Import the configs.
+import config
+
+# Initialize the API.
+api = privx_api.PrivXAPI(config.HOSTNAME, config.HOSTPORT, config.CA_CERT,
+                         config.OAUTH_CLIENT_ID, config.OAUTH_CLIENT_SECRET)
+
+# Authenticate.
+# NOTE: fill in your credentials from secure storage, this is just an example
+api.authenticate("API client ID", "API client secret")
+
+def usage():
+    print("Example for fetching AWS temporary access token via PrivX role.\nRequires mapping AWS role to PrivX role in PrivX admin console.\nIf PrivX user has a role with AWS role mapping, you can use '-r awsroleid' to acquire a token with assumed permissions via PrivX.\n")
+    print(sys.argv[0], "-h or --help")
+    print(sys.argv[0], "-r awsroleid")
+    print(sys.argv[0], "--awsrole awsroleid")
+    print(sys.argv[0], "--list")
+
+
+def print_awsroles(resp):
+    if resp.ok():
+        print(resp.data())
+    else:
+        print(resp.data())
+        sys.exit(2)
+
+def print_token(resp):
+    if resp.ok():
+        print(resp.data())
+    else:
+        print(resp.data())
+        sys.exit(2)
+
+def main():
+    if (len(sys.argv) < 2):
+        usage()
+        sys.exit(2)
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "hlr:", ["help", "list", "awsrole="])
+    except getopt.GetoptError:
+        usage()
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt in ("-h", "--help"):
+            usage()
+            sys.exit()
+        elif opt in ("-l", "--list"):
+            resp = api.list_awsroles()
+            print_awsroles(resp)
+        elif opt in ("-r", "--awsrole"):
+            resp = api.get_awstoken(arg, 900)
+            print_token(resp)
+        else:
+            usage()
+
+
+if __name__ == '__main__':
+    main()

--- a/privx_api/privx_api.py
+++ b/privx_api/privx_api.py
@@ -34,13 +34,14 @@ URLS = {
     "rolestore.sources": "/role-store/api/v1/sources",
     "rolestore.roles.members": "/role-store/api/v1/roles/{role_id}/members",
     "rolestore.role": "/role-store/api/v1/roles/{role_id}",
+    "rolestore.awsroles": "/role-store/api/v1/users/current/awsroles",
+    "rolestore.awstoken": "/role-store/api/v1/roles/{awsrole_id}/awstoken",
 
     "userstore.status": "/local-user-store/api/v1/status",
     "userstore.users": "/local-user-store/api/v1/users",
     "userstore.user": "/local-user-store/api/v1/users/{user_id}",
 
-    "connection.manager.search":
-        "/connection-manager/api/v1/connections/search",
+    "connection.manager.search": "/connection-manager/api/v1/connections/search",
 }
 
 
@@ -469,4 +470,32 @@ class PrivXAPI(object):
         response = self._http_post("connection.manager.search",
                                    query_params=search_params,
                                    body=kw)
+        return PrivXAPIResponse(response, 200)
+
+
+    # List accessible AWS roles.
+    #
+    def list_awsroles(self) -> PrivXAPIResponse:
+        """
+        Get AWS roles.
+
+        Returns:
+            PrivXAPIResponse
+        """
+        response = self._http_get("rolestore.awsroles")
+        return PrivXAPIResponse(response, response.status)
+
+    # Fetch temporary AWS token for given AWS role name and TTL.
+    # User needs to have the requested AWS role mapped to the available PrivX role by PrivX admin.
+    # Allowed TTL values 900-3600 seconds for assume-role (configurable max 43200) and 900-129600 for federation token.
+    def get_awstoken(self, awsrole_id: str, ttl: int = 900) -> PrivXAPIResponse:
+        """
+        Get temporary AWS token for given AWS role.
+
+        Returns:
+            PrivXAPIResponse
+        """
+        response = self._http_get("rolestore.awstoken",
+                                  path_params={'awsrole_id': awsrole_id},
+                                  query_params={'ttl': ttl})
         return PrivXAPIResponse(response, 200)


### PR DESCRIPTION
Added AWS temporary access token example. Requires PrivX 17 or above. See PrivX documentation for configuring PrivX and AWS IAM before use.
