### PR TITLE
Add delete_host(host_id) public method to PrivXAPI class

### DIFF
--- a/privx_api/privx_api.py
+++ b/privx_api/privx_api.py
@@ -349,6 +349,17 @@ class PrivXAPI(object):
                                    body=kw)
         return PrivXAPIResponse(response, 200)
 
+    def delete_host(self, host_id: str) -> PrivXAPIResponse:
+        """
+        Delete host record, required field host_id.
+
+        Returns:
+            PrivXAPIResponse
+        """
+        response = self._http_delete("hoststore.host",
+                                     path_params={'host_id': host_id})
+        return PrivXAPIResponse(response, 200)
+
     #
     # Role store API.
     #


### PR DESCRIPTION
This is to add missing delete_host(host_id) public method to PrivXAPI class.
The method uses internal function _http_delete (rest DELETE request) against /host-store/api/v1/hosts/{host_id} resource and returns PrivXAPIResponse object.