### PR TITLE
Bugfix, Non-auth-api-method were fixed by handling auth_required para…

### DIFF
--- a/privx_api/auth.py
+++ b/privx_api/auth.py
@@ -27,5 +27,5 @@ class AuthAPI(BasePrivXAPI):
         Returns:
             PrivXAPIResponse
         """
-        response_status, data = self._http_get(UrlEnum.AUTH.STATUS)
+        response_status, data = self._http_get(UrlEnum.AUTH.STATUS, auth_required=False)
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)

--- a/privx_api/authorizer.py
+++ b/privx_api/authorizer.py
@@ -15,7 +15,9 @@ class AuthorizerAPI(BasePrivXAPI):
         Returns:
             PrivXAPIResponse
         """
-        response_status, data = self._http_get(UrlEnum.AUTHORIZER.STATUS)
+        response_status, data = self._http_get(
+            UrlEnum.AUTHORIZER.STATUS, auth_required=False
+        )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
     def get_authorizer_cert(
@@ -32,6 +34,7 @@ class AuthorizerAPI(BasePrivXAPI):
             query_params={"access_group_id": access_group_id}
             if access_group_id
             else None,
+            auth_required=False,
         )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
@@ -43,7 +46,9 @@ class AuthorizerAPI(BasePrivXAPI):
             PrivXStreamResponse
         """
         response = self._http_stream(
-            UrlEnum.AUTHORIZER.AUTHORIZER_CERT_ID, path_params={"id": cert_id}
+            UrlEnum.AUTHORIZER.AUTHORIZER_CERT_ID,
+            path_params={"id": cert_id},
+            auth_required=False,
         )
         return PrivXStreamResponse(response, HTTPStatus.OK)
 
@@ -55,7 +60,9 @@ class AuthorizerAPI(BasePrivXAPI):
             PrivXStreamResponse
         """
         response = self._http_stream(
-            UrlEnum.AUTHORIZER.CERT_REVOCATION_LIST, path_params={"id": cert_id}
+            UrlEnum.AUTHORIZER.CERT_REVOCATION_LIST,
+            path_params={"id": cert_id},
+            auth_required=False,
         )
         return PrivXStreamResponse(response, HTTPStatus.OK)
 
@@ -195,6 +202,7 @@ class AuthorizerAPI(BasePrivXAPI):
             UrlEnum.AUTHORIZER.COMPONENT_CERTS,
             path_params={"ca_type": ca_type},
             query_params=search_params,
+            auth_required=False,
         )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
@@ -211,6 +219,7 @@ class AuthorizerAPI(BasePrivXAPI):
         response = self._http_stream(
             UrlEnum.AUTHORIZER.COMPONENT_CERT,
             path_params={"id": cert_id, "ca_type": ca_type},
+            auth_required=False,
         )
         return PrivXStreamResponse(response, HTTPStatus.OK)
 
@@ -229,6 +238,7 @@ class AuthorizerAPI(BasePrivXAPI):
         response = self._http_stream(
             UrlEnum.AUTHORIZER.COMPONENT_CERT_REVOCATION_LIST,
             path_params={"id": cert_id, "ca_type": ca_type},
+            auth_required=False,
         )
         return PrivXStreamResponse(response, HTTPStatus.OK)
 
@@ -265,6 +275,7 @@ class AuthorizerAPI(BasePrivXAPI):
                 "trusted_client_id": trusted_client_id,
                 "session_id": session_id,
             },
+            auth_required=False,
         )
         return PrivXStreamResponse(response, HTTPStatus.OK)
 
@@ -300,6 +311,7 @@ class AuthorizerAPI(BasePrivXAPI):
                 "trusted_client_id": trusted_client_id,
                 "session_id": session_id,
             },
+            auth_required=False,
         )
         return PrivXStreamResponse(response, HTTPStatus.OK)
 
@@ -312,6 +324,7 @@ class AuthorizerAPI(BasePrivXAPI):
         """
         response = self._http_stream(
             UrlEnum.AUTHORIZER.DOWNLOAD_COMMAND_SCRIPT,
+            auth_required=False,
         )
         return PrivXStreamResponse(response, HTTPStatus.OK)
 
@@ -347,6 +360,7 @@ class AuthorizerAPI(BasePrivXAPI):
                 "trusted_client_id": trusted_client_id,
                 "session_id": session_id,
             },
+            auth_required=False,
         )
         return PrivXStreamResponse(response, HTTPStatus.OK)
 
@@ -382,6 +396,7 @@ class AuthorizerAPI(BasePrivXAPI):
                 "trusted_client_id": trusted_client_id,
                 "session_id": session_id,
             },
+            auth_required=False,
         )
         return PrivXStreamResponse(response, HTTPStatus.OK)
 
@@ -410,6 +425,7 @@ class AuthorizerAPI(BasePrivXAPI):
         """
         response_status, data = self._http_get(
             UrlEnum.AUTHORIZER.SSL_TRUST_ANCHOR,
+            auth_required=False,
         )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
@@ -422,6 +438,7 @@ class AuthorizerAPI(BasePrivXAPI):
         """
         response_status, data = self._http_get(
             UrlEnum.AUTHORIZER.EXTENDER_TRUST_ANCHOR,
+            auth_required=False,
         )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 

--- a/privx_api/connection_manager.py
+++ b/privx_api/connection_manager.py
@@ -15,7 +15,9 @@ class ConnectionManagerAPI(BasePrivXAPI):
         Returns:
             PrivXAPIResponse
         """
-        response_status, data = self._http_get(UrlEnum.CONNECTION_MANAGER.STATUS)
+        response_status, data = self._http_get(
+            UrlEnum.CONNECTION_MANAGER.STATUS, auth_required=False
+        )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
     def get_connections(
@@ -120,6 +122,7 @@ class ConnectionManagerAPI(BasePrivXAPI):
                 "file_id": file_id,
                 "session_id": session_id,
             },
+            auth_required=False,
         )
         return PrivXStreamResponse(response_obj, HTTPStatus.OK)
 
@@ -168,6 +171,7 @@ class ConnectionManagerAPI(BasePrivXAPI):
                 "session_id": session_id,
             },
             query_params=search_params,
+            auth_required=False,
         )
         return PrivXStreamResponse(response_obj, HTTPStatus.OK)
 

--- a/privx_api/enums.py
+++ b/privx_api/enums.py
@@ -403,13 +403,17 @@ class UrlEnum:
         list_urls = list(
             filter(
                 lambda inner_enum: inner_enum.urls.get(url_name),
-                (
-                    val
-                    for key, val in cls.__dict__.items()
-                    if key == key.upper() and not key.startswith("__")
-                ),
+                cls.to_dict().values(),
             )
         )
         if len(list_urls) != 1:
             raise InternalAPIException
         return list_urls[0].urls.get(url_name)
+
+    @classmethod
+    def to_dict(cls) -> dict:
+        return {
+            key: val
+            for key, val in cls.__dict__.items()
+            if key == key.upper() and not key.startswith("__")
+        }

--- a/privx_api/host_store.py
+++ b/privx_api/host_store.py
@@ -15,7 +15,9 @@ class HostStoreAPI(BasePrivXAPI):
         Returns:
             PrivXAPIResponse
         """
-        response_status, data = self._http_get(UrlEnum.HOST_STORE.STATUS)
+        response_status, data = self._http_get(
+            UrlEnum.HOST_STORE.STATUS, auth_required=False
+        )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
     def search_hosts(

--- a/privx_api/license_manager.py
+++ b/privx_api/license_manager.py
@@ -13,7 +13,9 @@ class LicenseManagerAPI(BasePrivXAPI):
         Returns:
             PrivXAPIResponse
         """
-        response_status, data = self._http_get(UrlEnum.LICENSE.STATUS)
+        response_status, data = self._http_get(
+            UrlEnum.LICENSE.STATUS, auth_required=False
+        )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
     def get_license(self) -> PrivXAPIResponse:

--- a/privx_api/monitor_service.py
+++ b/privx_api/monitor_service.py
@@ -14,7 +14,9 @@ class MonitorServiceAPI(BasePrivXAPI):
         Returns:
             PrivXAPIResponse
         """
-        response_status, data = self._http_get(UrlEnum.MONITOR.STATUS)
+        response_status, data = self._http_get(
+            UrlEnum.MONITOR.STATUS, auth_required=False
+        )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
     def get_privx_components_status(self) -> PrivXAPIResponse:
@@ -24,7 +26,9 @@ class MonitorServiceAPI(BasePrivXAPI):
         Returns:
             PrivXAPIResponse
         """
-        response_status, data = self._http_get(UrlEnum.MONITOR.COMPONENTS)
+        response_status, data = self._http_get(
+            UrlEnum.MONITOR.COMPONENTS, auth_required=False
+        )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
     def get_privx_component_status(self, hostname: str) -> PrivXAPIResponse:
@@ -35,7 +39,9 @@ class MonitorServiceAPI(BasePrivXAPI):
             PrivXAPIResponse
         """
         response_status, data = self._http_get(
-            UrlEnum.MONITOR.COMPONENT, path_params={"hostname": hostname}
+            UrlEnum.MONITOR.COMPONENT,
+            path_params={"hostname": hostname},
+            auth_required=False,
         )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
@@ -118,7 +124,9 @@ class MonitorServiceAPI(BasePrivXAPI):
         Returns:
             PrivXAPIResponse
         """
-        response_status, data = self._http_get(UrlEnum.MONITOR.INSTANCE_STATUS)
+        response_status, data = self._http_get(
+            UrlEnum.MONITOR.INSTANCE_STATUS, auth_required=False
+        )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
     def terminate_privx_instances(self) -> PrivXAPIResponse:

--- a/privx_api/role_store.py
+++ b/privx_api/role_store.py
@@ -16,6 +16,7 @@ class RoleStoreAPI(BasePrivXAPI):
         """
         response_status, data = self._http_get(
             UrlEnum.ROLE_STORE.STATUS,
+            auth_required=False,
         )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 

--- a/privx_api/settings_service.py
+++ b/privx_api/settings_service.py
@@ -14,7 +14,9 @@ class SettingsServiceAPI(BasePrivXAPI):
         Returns:
             PrivXAPIResponse
         """
-        response_status, data = self._http_get(UrlEnum.SETTINGS.STATUS)
+        response_status, data = self._http_get(
+            UrlEnum.SETTINGS.STATUS, auth_required=False
+        )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
     def get_scope_settings(
@@ -86,6 +88,7 @@ class SettingsServiceAPI(BasePrivXAPI):
         response_status, data = self._http_get(
             UrlEnum.SETTINGS.SCOPE_SCHEMA,
             path_params={"scope": scope},
+            auth_required=False,
         )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
@@ -99,5 +102,6 @@ class SettingsServiceAPI(BasePrivXAPI):
         response_status, data = self._http_get(
             UrlEnum.SETTINGS.SCOPE_SECTION_SCHEMA,
             path_params={"scope": scope, "section": section},
+            auth_required=False,
         )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)

--- a/privx_api/tests/test_api.py
+++ b/privx_api/tests/test_api.py
@@ -122,6 +122,7 @@ def test_make_body_params(value, expected_value):
             {
                 "method": "GET",
                 "url_name": UrlEnum.CONNECTION_MANAGER.CONNECTIONS,
+                "auth_required": True,
                 "query_params": {"offset": "111", "limit": "20"},
             },
             {
@@ -137,6 +138,7 @@ def test_make_body_params(value, expected_value):
             {
                 "method": "GET",
                 "url_name": UrlEnum.CONNECTION_MANAGER.TRAIL_LOG_SESSION_ID,
+                "auth_required": True,
                 "query_params": {"format_param": "111", "filter_param": "20"},
                 "path_params": {
                     "connection_id": "1",
@@ -158,6 +160,7 @@ def test_make_body_params(value, expected_value):
             {
                 "method": "GET",
                 "url_name": UrlEnum.CONNECTION_MANAGER.TERMINATE_CONNECTION_ID,
+                "auth_required": True,
                 "query_params": {"format_param": "111", "filter_param": "20"},
                 "path_params": {
                     "connection_id": "1",
@@ -179,6 +182,7 @@ def test_make_body_params(value, expected_value):
             {
                 "method": "POST",
                 "url_name": UrlEnum.CONNECTION_MANAGER.TERMINATE_CONNECTION_ID,
+                "auth_required": True,
                 "path_params": {
                     "connection_id": "1",
                 },

--- a/privx_api/trail_index.py
+++ b/privx_api/trail_index.py
@@ -14,7 +14,9 @@ class TrailIndexAPI(BasePrivXAPI):
         Returns:
             PrivXAPIResponse
         """
-        response_status, data = self._http_get(UrlEnum.TRAIL_INDEX.STATUS)
+        response_status, data = self._http_get(
+            UrlEnum.TRAIL_INDEX.STATUS, auth_required=False
+        )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
     def get_indexing_status(self, conn_id: str) -> PrivXAPIResponse:

--- a/privx_api/user_store.py
+++ b/privx_api/user_store.py
@@ -14,7 +14,9 @@ class UserStoreAPI(BasePrivXAPI):
         Returns:
             PrivXAPIResponse
         """
-        response_status, data = self._http_get(UrlEnum.USER_STORE.STATUS)
+        response_status, data = self._http_get(
+            UrlEnum.USER_STORE.STATUS, auth_required=False
+        )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
     def get_users(

--- a/privx_api/vault.py
+++ b/privx_api/vault.py
@@ -15,7 +15,9 @@ class VaultAPI(BasePrivXAPI):
         Returns:
             PrivXAPIResponse
         """
-        response_status, data = self._http_get(UrlEnum.VAULT.STATUS)
+        response_status, data = self._http_get(
+            UrlEnum.VAULT.STATUS, auth_required=False
+        )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
     def create_secret(self, secret_params: dict) -> PrivXAPIResponse:

--- a/privx_api/workflow_engine.py
+++ b/privx_api/workflow_engine.py
@@ -14,7 +14,9 @@ class WorkFlowEngineAPI(BasePrivXAPI):
         Returns:
             PrivXAPIResponse
         """
-        response_status, data = self._http_get(UrlEnum.WORKFLOW_ENGINE.STATUS)
+        response_status, data = self._http_get(
+            UrlEnum.WORKFLOW_ENGINE.STATUS, auth_required=False
+        )
         return PrivXAPIResponse(response_status, HTTPStatus.OK, data)
 
     def get_workflows(


### PR DESCRIPTION
Adding the re_auth functional broke the endpoint which does not require a token in general.  So, I changed a bit rest-methods of  SDK in order to deal with such endpoints. 

now, for every method on the top-level of SDK, it's required to set `auth_required=False` for not using the re_auth method within that method call.  
By default all methods require authentication, meaning that  `auth_required=True` .