### PR TITLE
Change hostport typehint from string to int

### DIFF
--- a/privx_api/base.py
+++ b/privx_api/base.py
@@ -65,7 +65,7 @@ class BasePrivXAPI:
     def __init__(
         self,
         hostname: str,
-        hostport: str,
+        hostport: int,
         ca_cert: str,
         oauth_client_id: str,
         oauth_client_secret: str,


### PR DESCRIPTION
Both our examples and the http.client docs use int for the hostport
https://docs.python.org/3/library/http.client.html#http.client.HTTPSConnection