### PR TITLE
Added configurable fields from where to look for usernames for the access report

### DIFF
--- a/examples/get-roles-mapping-report.py
+++ b/examples/get-roles-mapping-report.py
@@ -31,10 +31,13 @@ api = privx_api.PrivXAPI(
 # NOTE: fill in your credentials from secure storage, this is just an example
 api.authenticate(config.API_CLIENT_ID, config.API_CLIENT_SECRET)
 
-# Default search order how to report user names in the output file. 
+# Default search order how to report user names in the output file.
 # NOTE: Not all user records have "principal" field defined necessarily,
 # hence the script will check samaccountname and DN fields as a backup
-username_attributes_to_check = ['principal', 'samaccountname', 'distinguished_name']
+username_attributes_to_check = ['principal',
+                                'samaccountname',
+                                'distinguished_name']
+
 
 def get_roles():
     resp = api.get_roles()
@@ -77,11 +80,12 @@ def get_role_mapping_data(role_id, role_name):
         for attribute in username_attributes_to_check:
             if attribute in member:
                 members.append(member[attribute])
-                # Break: no need to continue checking other attributes to find user name
+                # Break: Found username, no need to continue
                 break
         else:
-            print(f"Did not find user attribute, please configure script to use correct fields for user name attributes")
-            members.append(member["Username not defined in these attribute fields: {username_attributes_to_check}"])
+            # Did not find username, please configure script to
+            # use correct fields for user name attributes
+            members.append("UserID not found")
 
     members = ",".join(members)
     for host_data in data_load["items"]:

--- a/examples/get-roles-mapping-report.py
+++ b/examples/get-roles-mapping-report.py
@@ -53,6 +53,27 @@ def get_roles():
         process_error(error)
 
 
+def get_username_info(data):
+    """
+       Get usernames: check (configurable) list of fields to find usernames
+       Return: list of found usernames
+    """
+
+    app_members = []
+    # Get userID data according to username attribute configuration
+    for member in data["items"]:
+        for attribute in username_attributes_to_check:
+            if attribute in member:
+                app_members.append(member[attribute])
+                # Break: Found username, no need to continue
+                break
+        else:
+            # Did not find username, please configure script to
+            # use correct fields for user name attributes
+            app_members.append("UserID not found")
+    return app_members
+
+
 def get_role_mapping_data(role_id, role_name):
     resp = api.search_hosts(search_payload={"role": [role_id]})
     if not resp.ok:
@@ -74,19 +95,7 @@ def get_role_mapping_data(role_id, role_name):
     else:
         return None
     members = []
-
-    # Get userID data according to username attribute configuration
-    for member in data_load1["items"]:
-        for attribute in username_attributes_to_check:
-            if attribute in member:
-                members.append(member[attribute])
-                # Break: Found username, no need to continue
-                break
-        else:
-            # Did not find username, please configure script to
-            # use correct fields for user name attributes
-            members.append("UserID not found")
-
+    members = get_username_info(data_load1)
     members = ",".join(members)
     for host_data in data_load["items"]:
         accounts = []


### PR DESCRIPTION
Added configurable fields from where to look for usernames for the access report.

Not in every case the username resides in "principal" field. Sometimes the username can be for example, in the "samaccountname" field instead. Added an option for the user to configure how the script to try to find usernames for the access report.