### PR TITLE
WIP: Add single-step Authorizer download endpoints

### DIFF
--- a/examples/get-extender-config.py
+++ b/examples/get-extender-config.py
@@ -1,4 +1,4 @@
-# Download a pre-configured deployment script.
+# Download a pre-configured extender config.
 
 import json
 import sys

--- a/examples/get-extender-config.py
+++ b/examples/get-extender-config.py
@@ -1,0 +1,57 @@
+# Download a pre-configured deployment script.
+
+import json
+import sys
+
+import config
+
+# this importation for demonstration purpose only
+# for proper importation of privx_api module
+# see https://github.com/SSHcom/privx-sdk-for-python#getting-started
+try:
+    # Running example with pip-installed SDK
+    import privx_api
+except ImportError:
+    # Running example without installing SDK
+    from utils import load_privx_api_lib_path
+
+    load_privx_api_lib_path()
+    import privx_api
+
+# Initialize the API.
+api = privx_api.PrivXAPI(
+    config.HOSTNAME,
+    config.HOSTPORT,
+    config.CA_CERT,
+    config.OAUTH_CLIENT_ID,
+    config.OAUTH_CLIENT_SECRET,
+)
+
+# Authenticate.
+api.authenticate(config.API_CLIENT_ID, config.API_CLIENT_SECRET)
+
+
+# The trusted client ID for the extender config (required)
+EXTENDER_CONFIG_ID = ""
+OUTPUT_FILE = f"extender-{EXTENDER_CONFIG_ID}-config.toml"
+
+
+def main():
+    if not EXTENDER_CONFIG_ID:
+        print("Specify the EXTENDER_CONFIG_ID variable before running this script.")
+        sys.exit(1)
+
+    response = api.get_extender_config(trusted_client_id=EXTENDER_CONFIG_ID)
+
+    if not response.ok:
+        print("Failed to get extender config")
+        sys.exit(1)
+
+    with open(OUTPUT_FILE, "w") as f:
+        for char in response.iter_content():
+            f.write(char.decode("utf-8"))
+
+    print(f"Extender config written to {OUTPUT_FILE}.")
+
+if __name__ == "__main__":
+    main()

--- a/privx_api/authorizer.py
+++ b/privx_api/authorizer.py
@@ -239,6 +239,8 @@ class AuthorizerAPI(BasePrivXAPI):
         """
         Gets a extender-config.toml pre-configured for this PrivX installation.
 
+        Deprecated: use get_extender_config instead.
+
         Returns:
             PrivXAPIResponse
         """
@@ -256,6 +258,8 @@ class AuthorizerAPI(BasePrivXAPI):
         """
         Gets a extender-config.toml pre-configured for this PrivX installation.
 
+        Deprecated: use get_extender_config instead.
+
         Returns:
             PrivXStreamResponse
         """
@@ -268,11 +272,31 @@ class AuthorizerAPI(BasePrivXAPI):
         )
         return PrivXStreamResponse(response, HTTPStatus.OK)
 
+    def get_extender_config(
+        self,
+        trusted_client_id: str,
+    ) -> PrivXStreamResponse:
+        """
+        Gets a extender-config.toml pre-configured for this PrivX installation.
+
+        Returns:
+            PrivXStreamResponse
+        """
+        response = self._http_stream(
+            UrlEnum.AUTHORIZER.GET_EXTENDER_CONFIG,
+            path_params={
+                "trusted_client_id": trusted_client_id,
+            },
+        )
+        return PrivXStreamResponse(response, HTTPStatus.OK)
+
     def create_deployment_script_download_handle(
         self, trusted_client_id: str
     ) -> PrivXAPIResponse:
         """
         Gets a deployment script pre-configured for this PrivX installation.
+
+        Deprecated: use get_deployment_script instead.
 
         Returns:
             PrivXAPIResponse
@@ -291,6 +315,8 @@ class AuthorizerAPI(BasePrivXAPI):
         """
         Gets a deployment script pre-configured for this PrivX installation.
 
+        Deprecated: use get_deployment_script instead.
+
         Returns:
             PrivXStreamResponse
         """
@@ -299,6 +325,24 @@ class AuthorizerAPI(BasePrivXAPI):
             path_params={
                 "trusted_client_id": trusted_client_id,
                 "session_id": session_id,
+            },
+        )
+        return PrivXStreamResponse(response, HTTPStatus.OK)
+
+    def get_deployment_script(
+        self,
+        trusted_client_id: str,
+    ) -> PrivXStreamResponse:
+        """
+        Gets a deployment script pre-configured for this PrivX installation.
+
+        Returns:
+            PrivXStreamResponse
+        """
+        response = self._http_stream(
+            UrlEnum.AUTHORIZER.GET_DEPLOYMENT_SCRIPT,
+            path_params={
+                "trusted_client_id": trusted_client_id,
             },
         )
         return PrivXStreamResponse(response, HTTPStatus.OK)
@@ -321,6 +365,8 @@ class AuthorizerAPI(BasePrivXAPI):
         """
         Gets a carrier-config.toml pre-configured for this PrivX installation.
 
+        Deprecated: use get_carrier_config instead.
+
         Returns:
             PrivXStreamResponse
         """
@@ -338,6 +384,8 @@ class AuthorizerAPI(BasePrivXAPI):
         """
         Gets a carrier-config.toml pre-configured for this PrivX installation.
 
+        Deprecated: use get_carrier_config instead.
+
         Returns:
             PrivXStreamResponse
         """
@@ -349,12 +397,32 @@ class AuthorizerAPI(BasePrivXAPI):
             },
         )
         return PrivXStreamResponse(response, HTTPStatus.OK)
+    
+    def get_carrier_config(
+        self,
+        trusted_client_id: str,
+    ) -> PrivXStreamResponse:
+        """
+        Gets a carrier-config.toml pre-configured for this PrivX installation.
+
+        Returns:
+            PrivXStreamResponse
+        """
+        response = self._http_stream(
+            UrlEnum.AUTHORIZER.GET_CARRIER_CONFIG,
+            path_params={
+                "trusted_client_id": trusted_client_id,
+            },
+        )
+        return PrivXStreamResponse(response, HTTPStatus.OK)
 
     def create_web_proxy_config_download_handle(
         self, trusted_client_id: str
     ) -> PrivXAPIResponse:
         """
         Gets a web-proxy-config.toml pre-configured for this PrivX installation.
+
+        Deprecated: use get_web_proxy_config instead.
 
         Returns:
             PrivXStreamResponse
@@ -373,6 +441,8 @@ class AuthorizerAPI(BasePrivXAPI):
         """
         Gets a web-proxy-config.toml pre-configured for this PrivX installation.
 
+        Deprecated: use get_web_proxy_config instead.
+
         Returns:
             PrivXStreamResponse
         """
@@ -381,6 +451,24 @@ class AuthorizerAPI(BasePrivXAPI):
             path_params={
                 "trusted_client_id": trusted_client_id,
                 "session_id": session_id,
+            },
+        )
+        return PrivXStreamResponse(response, HTTPStatus.OK)
+
+    def get_web_proxy_config(
+        self,
+        trusted_client_id: str,
+    ) -> PrivXStreamResponse:
+        """
+        Gets a web-proxy-config.toml pre-configured for this PrivX installation.
+
+        Returns:
+            PrivXStreamResponse
+        """
+        response = self._http_stream(
+            UrlEnum.AUTHORIZER.GET_WEB_PROXY_CONFIG,
+            path_params={
+                "trusted_client_id": trusted_client_id,
             },
         )
         return PrivXStreamResponse(response, HTTPStatus.OK)

--- a/privx_api/enums.py
+++ b/privx_api/enums.py
@@ -399,11 +399,15 @@ class AuthorizerEnum:
     CREATE_GROUP_PRINCIPAL_KEY = "AUTHORIZER.CREATE_GROUP_PRINCIPAL_KEY"
     DEPLOYMENT_SCRIPT_SESSION_ID = "AUTHORIZER.DEPLOYMENT_SCRIPT_SESSION_ID"
     DOWNLOAD_CARRIER_CONFIG = "AUTHORIZER.DOWNLOAD_CARRIER_CONFIG"
+    GET_CARRIER_CONFIG = "AUTHORIZER.GET_CARRIER_CONFIG"
     DOWNLOAD_COMMAND_SCRIPT = "AUTHORIZER.DOWNLOAD_COMMAND_SCRIPT"
     DOWNLOAD_DEPLOYMENT_SCRIPT = "AUTHORIZER.DOWNLOAD_DEPLOYMENT_SCRIPT"
+    GET_DEPLOYMENT_SCRIPT = "AUTHORIZER.GET_DEPLOYMENT_SCRIPT"
     DOWNLOAD_WEB_PROXY_CONFIG = "AUTHORIZER.DOWNLOAD_WEB_PROXY_CONFIG"
+    GET_WEB_PROXY_CONFIG = "AUTHORIZER.GET_WEB_PROXY_CONFIG"
     EXTENDER_CONFIG = "AUTHORIZER.EXTENDER_CONFIG"
     EXTENDER_CONFIG_SESSION_ID = "AUTHORIZER.EXTENDER_CONFIG_SESSION_ID"
+    GET_EXTENDER_CONFIG = "AUTHORIZER.GET_EXTENDER_CONFIG"
     EXTENDER_TRUST_ANCHOR = "AUTHORIZER.EXTENDER_TRUST_ANCHOR"
     GET_CERT_BY_ID = "AUTHORIZER.GET_CERT_BY_ID"
     GET_CERTIFICATES_LIST = "AUTHORIZER.GET_CERTIFICATES_LIST"
@@ -436,15 +440,19 @@ class AuthorizerEnum:
         DEPLOYMENT_SCRIPT_SESSION_ID: "/authorizer/api/v1/deploy/{trusted_client_id}",
         DOWNLOAD_CARRIER_CONFIG: "/authorizer/api/v1/carrier/conf/{trusted_client_id}"
         "/{session_id}",
+        GET_CARRIER_CONFIG: "/authorizer/api/v1/carrier/conf/{trusted_client_id}",
         DOWNLOAD_COMMAND_SCRIPT: "/authorizer/api/v1/deploy/principals_command.sh",
         DOWNLOAD_DEPLOYMENT_SCRIPT: "/authorizer/api/v1/deploy/{trusted_client_id}/{"
         "session_id}",
+        GET_DEPLOYMENT_SCRIPT: "/authorizer/api/v1/deploy/{trusted_client_id}",
         DOWNLOAD_WEB_PROXY_CONFIG: "/authorizer/api/v1/icap/conf/{trusted_client_id}"
         "/{session_id}",
+        GET_WEB_PROXY_CONFIG: "/authorizer/api/v1/icap/conf/{trusted_client_id}",
         EXTENDER_CONFIG: "/authorizer/api/v1/extender/conf/{trusted_client_id}"
         "/{session_id}",
         EXTENDER_CONFIG_SESSION_ID: "/authorizer/api/v1/extender/conf"
         "/{trusted_client_id}",
+        GET_EXTENDER_CONFIG: "/authorizer/api/v1/extender/conf/{trusted_client_id}",
         EXTENDER_TRUST_ANCHOR: "/authorizer/api/v1/extender-trust-anchor",
         GET_CERT_BY_ID: "/authorizer/api/v1/cert/{id}",
         GET_CERTIFICATES_LIST: "/authorizer/api/v1/cert",


### PR DESCRIPTION
Adds support for the single-step download endpoints for downloading extender, web-proxy and carrier configs as well as deployment scripts.

Also adds an example script for downloading an extender config.

This needs some more discussion.